### PR TITLE
Fix dead links to contributing pages

### DIFF
--- a/bug-triage/introduction.md
+++ b/bug-triage/introduction.md
@@ -64,7 +64,7 @@ Bisecting can be done at multiple levels, the basic level is checking if, for ex
 confirmed on `4.4` is also reproducible on `4.3`. Next you can test development releases, such as `4.4.beta1`,
 these can be found in the [Godot archive](https://godotengine.org/download/archive/).
 Once the specific development release has been identified you can go one step further and
-[bisect](https://docs.godotengine.org/en/latest/contributing/workflow/bisecting_regressions.html) the regression.
+[bisect](https://contributing.godotengine.org/en/latest/reporting_issues/bisecting.html) the regression.
 
 Make sure to announce the fact that you are bisecting a bug on the issue report to make sure no one else starts
 bisecting it as well, as bisecting can take some time.

--- a/bug-triage/team-trackers.md
+++ b/bug-triage/team-trackers.md
@@ -21,7 +21,7 @@ Some GitHub labels aren't neatly covered by trackers, below is a list of teams a
   - [godotengine/tests](https://github.com/godotengine/godot/pulls?q=is%3Apr+is%3Aopen+team-review-requested%3Agodotengine%2Ftests)
   - `topic:tests` [issues](https://github.com/godotengine/godot/issues?q=is%3Aissue%20state%3Aopen%20label%3Atopic%3Atests) [PRs](https://github.com/godotengine/godot/pulls?q=is%3Apr+is%3Aopen+label%3Atopic%3Atests)
 
-For more information about the different GitHub labels, please see the [labels documentation](https://docs.godotengine.org/en/latest/contributing/workflow/bug_triage_guidelines.html#labels).
+For more information about the different GitHub labels, please see the [labels documentation](https://contributing.godotengine.org/en/latest/triage/guidelines.html#labels).
 
 <!-- TODO: Consider using a table -->
 

--- a/bug-triage/triage-workflow.md
+++ b/bug-triage/triage-workflow.md
@@ -44,7 +44,7 @@ Issues that are clearly spam should be closed and tagged as “spam” and marke
 ## Initial Assessment
 
 Once the basic details of the issue have been verified the issue should be tagged with the appropriate tags.
-See [bug triage guidelines](https://docs.godotengine.org/en/latest/contributing/workflow/bug_triage_guidelines.html) for details on these tags.
+See [bug triage guidelines](https://contributing.godotengine.org/en/latest/triage/guidelines.html) for details on these tags.
 
 If the bug is reported on the current development version (i.e. the `master` branch, and any pre-releases such as `4.4.beta1`) it is important to verify if it also occurs
 on a past stable release. If this information is missing from the report (i.e. the author only reports having tested development versions) please either ask the author to
@@ -109,7 +109,7 @@ If you are unable to reproduce the bug, and the author reports using a different
 
 For pre-release versions, it's critical to identify what change caused a specific bug. **All** such regressions should be bisected.
 You can ask the issue author to follow the instructions in the
-[Bisecting regressions](https://docs.godotengine.org/en/latest/contributing/workflow/bisecting_regressions.html) documentation.
+[Bisecting regressions](https://contributing.godotengine.org/en/latest/reporting_issues/bisecting.html) documentation.
 If they are not able to (or the issue is critical and should be fixed as quickly as possible), then you can look into bisecting the issue yourself.
 
 Once identified correctly it should be put on the relevant triage project(s) if appropriate. See [team trackers](/bug-triage/team-trackers.md) for a list of triage projects.


### PR DESCRIPTION
URLs broken starting with Godot 4.5

Can this PR be squashed to 1 commit by the maintainers? I see no option in github's UI…

_EDIT_: never mind, didn't see the other PR